### PR TITLE
Fix localized port formatting in connection displays

### DIFF
--- a/Clauntty/Models/SavedConnection.swift
+++ b/Clauntty/Models/SavedConnection.swift
@@ -32,6 +32,16 @@ struct SavedConnection: Codable, Identifiable, Hashable {
     var displayName: String {
         name.isEmpty ? "\(username)@\(host)" : name
     }
+
+    /// SSH endpoint with optional custom port.
+    /// Uses raw numeric port formatting (no locale grouping separators).
+    var endpointDisplay: String {
+        if port == 22 {
+            return "\(username)@\(host)"
+        }
+        
+        return "\(username)@\(host):\(port)"
+    }
 }
 
 /// Authentication method for SSH connections

--- a/Clauntty/Views/ConnectionListView.swift
+++ b/Clauntty/Views/ConnectionListView.swift
@@ -223,12 +223,7 @@ struct ConnectionRow: View {
             VStack(alignment: .leading, spacing: 4) {
                 Text(connection.displayName)
                     .font(.headline)
-                HStack(spacing: 4) {
-                    Text("\(connection.username)@\(connection.host)")
-                    if connection.port != 22 {
-                        Text(":\(connection.port)")
-                    }
-                }
+                Text(connection.endpointDisplay)
                 .font(.subheadline)
                 .foregroundColor(.secondary)
             }

--- a/Clauntty/Views/LiquidGlassTabBar/FullTabSelector.swift
+++ b/Clauntty/Views/LiquidGlassTabBar/FullTabSelector.swift
@@ -466,12 +466,12 @@ struct ForwardedPortRow: View {
     var body: some View {
         HStack {
             VStack(alignment: .leading, spacing: 2) {
-                Text(":\(port.remotePort.port)")
+                Text(":\(String(port.remotePort.port))")
                     .font(.system(.body, design: .monospaced))
                     .fontWeight(.medium)
                     .foregroundColor(.white)
 
-                Text("localhost:\(port.localPort) → \(port.connectionConfig.host)")
+                Text("localhost:\(String(port.localPort)) → \(port.connectionConfig.host)")
                     .font(.caption)
                     .foregroundColor(.gray)
             }

--- a/Clauntty/Views/ServerPickerView.swift
+++ b/Clauntty/Views/ServerPickerView.swift
@@ -94,7 +94,7 @@ struct ServerRow: View {
                     .font(.body)
                     .fontWeight(.medium)
 
-                Text("\(connection.username)@\(connection.host)")
+                Text(connection.endpointDisplay)
                     .font(.caption)
                     .foregroundColor(.secondary)
             }

--- a/Clauntty/Views/WebTabView.swift
+++ b/Clauntty/Views/WebTabView.swift
@@ -19,7 +19,7 @@ struct WebTabView: View {
             case .connecting:
                 VStack(spacing: 16) {
                     ProgressView()
-                    Text("Connecting to port \(webTab.remotePort.port)...")
+                    Text("Connecting to port \(String(webTab.remotePort.port))...")
                         .foregroundColor(.secondary)
                 }
                 .frame(maxWidth: .infinity, maxHeight: .infinity)


### PR DESCRIPTION
## Title
  Fix custom port display formatting across server/port UI

  ## Summary
  Custom SSH ports were being displayed with locale grouping separators in some views (for example `2121` appearing as `2,121`). This PR normalizes port
  rendering so ports are always shown as raw numeric values.

  ## Problem
  - In SwiftUI, `Text("...\(int)...")` can localize numeric interpolation.
  - That behavior caused confusing port display in UI and raised concern that ports might be saved incorrectly.

  ## Root Cause
  - UI formatting issue only: localized `Int` interpolation in `Text`.
  - Persistence and usage were already correct (`port` is stored as `Int`, encoded/decoded via `Codable`, and passed directly into `SSHConnection`).

  ## What Changed
  - Added `SavedConnection.endpointDisplay` to centralize endpoint formatting and append custom port when non-default.
  - Updated server rows to use `endpointDisplay`:
    - `Clauntty/Views/ServerPickerView.swift`
    - `Clauntty/Views/ConnectionListView.swift`
  - Replaced direct `Int` interpolation with explicit string conversion in other port labels:
    - `Clauntty/Views/WebTabView.swift`
    - `Clauntty/Views/LiquidGlassTabBar/FullTabSelector.swift`

  ## Validation
  - Built successfully with `xcodebuild` (iOS Simulator target).
  - Verified changes are display-only and do not alter persistence schema or SSH connection behavior.

  ## Risk / Impact
  - Low risk.
  - No data migration.
  - No auth/session/network logic changes.