### PR TITLE
Add Justfile for build automation

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -1,0 +1,308 @@
+# Clauntty justfile — `just -l` to list all recipes
+
+# --- Defaults (override with env vars) ---------------------------------------
+PROJECT       := "Clauntty.xcodeproj"
+SCHEME        := "Clauntty"
+SIM_DEVICE    := env("SIM_DEVICE", "iPhone 17")
+CONFIGURATION := env("CONFIGURATION", "Debug")
+
+# Release / archive
+ARCHIVE_CONFIGURATION := env("ARCHIVE_CONFIGURATION", "Release")
+ARCHIVE_PATH          := env("ARCHIVE_PATH", "build/Clauntty.xcarchive")
+EXPORT_PATH           := env("EXPORT_PATH", "build/export")
+EXPORT_OPTIONS_PLIST  := env("EXPORT_OPTIONS_PLIST", "ExportOptions.plist")
+EXPORT_METHOD         := env("EXPORT_METHOD", "")
+
+# Fork identity
+BUNDLE_ID  := env("BUNDLE_ID", "com.octerm.clauntty")
+TEAM_ID    := env("TEAM_ID", "65533RB4LC")
+URL_SCHEME := env("URL_SCHEME", "clauntty")
+
+# Sibling repos (as per repo layout in CLAUDE.md)
+GHOSTTY_DIR := env("GHOSTTY_DIR", "../ghostty")
+RTACH_DIR   := env("RTACH_DIR", "../rtach")
+LIBXEV_DIR  := env("LIBXEV_DIR", "../libxev")
+
+# Sibling repo git URLs and branches
+GHOSTTY_REPO   := env("GHOSTTY_REPO", "https://github.com/eriklangille/ghostty.git")
+GHOSTTY_BRANCH := env("GHOSTTY_BRANCH", "clauntty")
+RTACH_REPO     := env("RTACH_REPO", "https://github.com/eriklangille/rtach.git")
+LIBXEV_REPO    := env("LIBXEV_REPO", "https://github.com/eriklangille/libxev.git")
+
+# --- Default ----------------------------------------------------------------
+
+default:
+  @just --list
+
+# --- Setup ------------------------------------------------------------------
+
+# Clone sibling repos (ghostty, rtach, libxev) if missing.
+[group("setup")]
+setup:
+  #!/usr/bin/env bash
+  set -euo pipefail
+  clone_if_missing() {
+    local dir="$1" repo="$2"
+    if [ -d "$dir" ]; then
+      echo "OK: $dir already exists"
+    else
+      echo "Cloning $repo -> $dir ..."
+      git clone "$repo" "$dir"
+      echo "OK: cloned $dir"
+    fi
+  }
+  clone_if_missing "{{GHOSTTY_DIR}}" "{{GHOSTTY_REPO}}"
+  clone_if_missing "{{RTACH_DIR}}"   "{{RTACH_REPO}}"
+  clone_if_missing "{{LIBXEV_DIR}}"  "{{LIBXEV_REPO}}"
+
+  # Ghostty needs the clauntty branch (has iOS-specific APIs)
+  current="$(cd "{{GHOSTTY_DIR}}" && git rev-parse --abbrev-ref HEAD)"
+  if [ "$current" != "{{GHOSTTY_BRANCH}}" ]; then
+    echo "Switching ghostty to branch {{GHOSTTY_BRANCH}}..."
+    (cd "{{GHOSTTY_DIR}}" && git checkout "{{GHOSTTY_BRANCH}}")
+  fi
+
+# --- Preflight checks -------------------------------------------------------
+
+# Run all environment + layout checks.
+[group("check")]
+doctor: _check-macos _check-tools _check-xcode _check-metal _check-zig _check-layout
+
+[private]
+_check-macos:
+  #!/usr/bin/env bash
+  set -euo pipefail
+  [ "$(uname -s)" = "Darwin" ] || { echo "ERROR: macOS required." >&2; exit 1; }
+  echo "OK: macOS"
+
+[private]
+_check-tools:
+  #!/usr/bin/env bash
+  set -euo pipefail
+  need() { command -v "$1" >/dev/null 2>&1 || { echo "ERROR: missing: $1" >&2; exit 1; }; }
+  need git; need xcodebuild; need xcrun; need swift; need plutil; need perl
+  [ -x /usr/libexec/PlistBuddy ] || { echo "ERROR: missing PlistBuddy" >&2; exit 1; }
+  echo "OK: tools"
+
+[private]
+_check-xcode:
+  #!/usr/bin/env bash
+  set -euo pipefail
+  xcodebuild -version >/dev/null 2>&1 || { echo "ERROR: Xcode not found." >&2; exit 1; }
+  xver="$(xcodebuild -version | head -1 | awk '{print $2}')"
+  major="${xver%%.*}"
+  [ -n "$major" ] && [ "$major" -ge 15 ] || { echo "ERROR: Xcode 15+ required (found ${xver})" >&2; exit 1; }
+  echo "OK: Xcode ${xver}"
+
+[private]
+_check-metal:
+  #!/usr/bin/env bash
+  set -euo pipefail
+  if xcrun -sdk macosx metal --version >/dev/null 2>&1; then
+    echo "OK: Metal Toolchain"
+  else
+    echo "Metal Toolchain missing, installing..."
+    xcodebuild -downloadComponent MetalToolchain
+    echo "OK: Metal Toolchain installed"
+  fi
+
+[private]
+_check-zig:
+  #!/usr/bin/env bash
+  set -euo pipefail
+  command -v zig >/dev/null 2>&1 || { echo "ERROR: zig not found." >&2; exit 1; }
+  zv="$(zig version)"
+  zmaj="${zv%%.*}"; _r="${zv#*.}"; zmin="${_r%%.*}"; zp="${_r#*.}"; zp="${zp%%[^0-9]*}"
+  ok=0
+  [ "$zmaj" -gt 0 ] && ok=1
+  [ "$zmaj" -eq 0 ] && [ "$zmin" -gt 15 ] && ok=1
+  [ "$zmaj" -eq 0 ] && [ "$zmin" -eq 15 ] && [ "${zp:-0}" -ge 2 ] && ok=1
+  [ "$ok" -eq 1 ] || { echo "ERROR: Zig 0.15.2+ required (found ${zv})" >&2; exit 1; }
+  echo "OK: Zig ${zv}"
+
+[private]
+_check-layout:
+  #!/usr/bin/env bash
+  set -euo pipefail
+  [ -d "{{GHOSTTY_DIR}}" ] || { echo "ERROR: missing {{GHOSTTY_DIR}}" >&2; exit 1; }
+  [ -d "{{RTACH_DIR}}" ]   || { echo "ERROR: missing {{RTACH_DIR}}" >&2; exit 1; }
+  [ -d "{{LIBXEV_DIR}}" ]  || { echo "ERROR: missing {{LIBXEV_DIR}}" >&2; exit 1; }
+  [ -d "{{GHOSTTY_DIR}}/../libxev" ] || { echo "ERROR: ghostty expects ../libxev" >&2; exit 1; }
+  echo "OK: layout"
+
+# --- Dependencies ------------------------------------------------------------
+
+# Build GhosttyKit xcframework.
+[group("deps")]
+deps-ghostty:
+  cd "{{GHOSTTY_DIR}}" && zig build -Demit-xcframework -Doptimize=ReleaseFast
+
+# Build rtach cross-compiled binaries.
+[group("deps")]
+deps-rtach:
+  cd "{{RTACH_DIR}}" && zig build cross
+
+# Symlink GhosttyKit.xcframework into Frameworks/ if missing.
+[group("deps")]
+deps-link:
+  #!/usr/bin/env bash
+  set -euo pipefail
+  dst="Frameworks/GhosttyKit.xcframework"
+  rel="../../$(basename "{{GHOSTTY_DIR}}")/macos/GhosttyKit.xcframework"
+  if [ -e "$dst" ]; then echo "OK: $dst exists"; exit 0; fi
+  abs="$(cd "{{GHOSTTY_DIR}}/macos" && pwd)/GhosttyKit.xcframework"
+  [ -e "$abs" ] || { echo "ERROR: build GhosttyKit first (just deps-ghostty)" >&2; exit 1; }
+  mkdir -p "$(dirname "$dst")"
+  ln -s "$rel" "$dst"
+  echo "OK: symlinked $dst -> $rel"
+
+# Copy rtach binaries into app resources (needed after rtach rebuild).
+[group("deps")]
+copy-rtach:
+  #!/usr/bin/env bash
+  set -euo pipefail
+  mkdir -p Clauntty/Resources/rtach
+  cp "{{RTACH_DIR}}"/zig-out/bin/rtach-* Clauntty/Resources/rtach/
+  echo "OK: rtach binaries copied"
+
+# Build all deps: setup + doctor + ghostty + rtach (parallel) + link + copy rtach.
+[group("deps")]
+deps: setup doctor _deps-build deps-link copy-rtach
+
+[private]
+[parallel]
+_deps-build: deps-ghostty deps-rtach
+
+# --- Build / Test ------------------------------------------------------------
+
+# Build for iOS Simulator (runs deps first).
+[group("build")]
+build: deps build-only
+
+# Build without re-running deps (faster iteration).
+[group("build")]
+build-only:
+  #!/usr/bin/env bash
+  set -euo pipefail
+  echo "Building for Simulator: {{SIM_DEVICE}} ({{CONFIGURATION}})"
+  xcodebuild \
+    -project "{{PROJECT}}" -scheme "{{SCHEME}}" \
+    -configuration "{{CONFIGURATION}}" \
+    -destination "platform=iOS Simulator,name={{SIM_DEVICE}}" \
+    -quiet build
+  echo "OK: build complete."
+
+# Run unit tests on Simulator.
+[group("build")]
+test:
+  #!/usr/bin/env bash
+  set -euo pipefail
+  echo "Running tests on: {{SIM_DEVICE}}"
+  xcodebuild test \
+    -project "{{PROJECT}}" -scheme "ClaunttyTests" \
+    -destination "platform=iOS Simulator,name={{SIM_DEVICE}}" \
+    -quiet
+  echo "OK: tests passed."
+
+# --- Release -----------------------------------------------------------------
+
+# Build .xcarchive for device (signing required).
+[group("release")]
+archive: deps
+  #!/usr/bin/env bash
+  set -euo pipefail
+  echo "Archiving to: {{ARCHIVE_PATH}}"
+  mkdir -p "$(dirname "{{ARCHIVE_PATH}}")"
+  xcodebuild \
+    -project "{{PROJECT}}" -scheme "{{SCHEME}}" \
+    -configuration "{{ARCHIVE_CONFIGURATION}}" \
+    -destination "generic/platform=iOS" \
+    -archivePath "{{ARCHIVE_PATH}}" \
+    -allowProvisioningUpdates archive \
+    DEVELOPMENT_TEAM="{{TEAM_ID}}" \
+    PRODUCT_BUNDLE_IDENTIFIER="{{BUNDLE_ID}}" \
+    -quiet
+  echo "OK: archive at {{ARCHIVE_PATH}}"
+
+# Export .ipa from archive (needs ExportOptions.plist).
+[group("release")]
+ipa: archive
+  #!/usr/bin/env bash
+  set -euo pipefail
+  [ -d "{{ARCHIVE_PATH}}" ] || { echo "ERROR: no archive at {{ARCHIVE_PATH}}" >&2; exit 1; }
+  [ -f "{{EXPORT_OPTIONS_PLIST}}" ] || { echo "ERROR: missing {{EXPORT_OPTIONS_PLIST}}" >&2; exit 1; }
+  mkdir -p "{{EXPORT_PATH}}"
+  _tmp="{{EXPORT_PATH}}/_ExportOptions.plist"
+  cp "{{EXPORT_OPTIONS_PLIST}}" "$_tmp"
+  [ -z "{{EXPORT_METHOD}}" ] || plutil -replace method -string "{{EXPORT_METHOD}}" "$_tmp"
+  [ -z "{{TEAM_ID}}" ]       || plutil -replace teamID -string "{{TEAM_ID}}" "$_tmp"
+  echo "Exporting IPA to: {{EXPORT_PATH}}"
+  xcodebuild -exportArchive \
+    -archivePath "{{ARCHIVE_PATH}}" \
+    -exportPath "{{EXPORT_PATH}}" \
+    -exportOptionsPlist "$_tmp" \
+    -allowProvisioningUpdates -quiet
+  rm -f "$_tmp"
+  echo "OK: IPA exported to {{EXPORT_PATH}}"
+
+# --- Configure ---------------------------------------------------------------
+
+# Patch bundle ID, team ID, URL scheme into pbxproj + plists + sim.sh.
+[group("config")]
+configure $bundle_id $team_id $url_scheme:
+  #!/usr/bin/env bash
+  set -euo pipefail
+  echo "Patching: BUNDLE_ID=$bundle_id  TEAM_ID=$team_id  URL_SCHEME=$url_scheme"
+  pbxproj="Clauntty.xcodeproj/project.pbxproj"
+
+  if [ -f "{{EXPORT_OPTIONS_PLIST}}" ]; then
+    plutil -replace teamID -string "$team_id" "{{EXPORT_OPTIONS_PLIST}}"
+    echo "  OK: {{EXPORT_OPTIONS_PLIST}}"
+  fi
+
+  if [ -f "Clauntty/Info.plist" ]; then
+    /usr/libexec/PlistBuddy -c "Set :CFBundleURLTypes:0:CFBundleURLName $bundle_id" "Clauntty/Info.plist" 2>/dev/null || true
+    /usr/libexec/PlistBuddy -c "Set :CFBundleURLTypes:0:CFBundleURLSchemes:0 $url_scheme" "Clauntty/Info.plist" 2>/dev/null || true
+    echo "  OK: Clauntty/Info.plist"
+  fi
+
+  if [ -f "scripts/sim.sh" ]; then
+    perl -pi -e 's/^BUNDLE_ID="[^"]+"/BUNDLE_ID="'"${bundle_id//\//\\/}"'"/' "scripts/sim.sh"
+    perl -pi -e 's/[A-Za-z0-9+.-]+:\/\//'"${url_scheme//\//\\/}"':\/\//g' "scripts/sim.sh"
+    echo "  OK: scripts/sim.sh"
+  fi
+
+  if [ -f "$pbxproj" ]; then
+    perl -pi -e 's/PRODUCT_BUNDLE_IDENTIFIER = [^;]+;/PRODUCT_BUNDLE_IDENTIFIER = '"${bundle_id//\//\\/}"';/g' "$pbxproj"
+    perl -pi -e 's/DEVELOPMENT_TEAM = [^;]+;/DEVELOPMENT_TEAM = '"${team_id//\//\\/}"';/g' "$pbxproj"
+    echo "  OK: $pbxproj"
+  fi
+
+  echo "Done. Run 'just doctor' to verify."
+
+# --- Clean -------------------------------------------------------------------
+
+# Clean everything: Xcode, DerivedData, zig outputs, framework link.
+[group("clean")]
+[confirm("This will remove build artifacts, DerivedData, and zig outputs. Continue?")]
+clean: clean-xcode clean-derived clean-zig clean-link
+
+# Xcode clean only.
+[group("clean")]
+clean-xcode:
+  -xcodebuild -project "{{PROJECT}}" -scheme "{{SCHEME}}" -quiet clean 2>/dev/null
+
+# Remove DerivedData for Clauntty.
+[group("clean")]
+clean-derived:
+  @rm -rf "${HOME}/Library/Developer/Xcode/DerivedData/Clauntty-"* && echo "OK: DerivedData cleaned"
+
+# Remove zig-out/zig-cache in ghostty + rtach.
+[group("clean")]
+clean-zig:
+  @rm -rf "{{GHOSTTY_DIR}}/zig-out" "{{GHOSTTY_DIR}}/zig-cache" "{{RTACH_DIR}}/zig-out" "{{RTACH_DIR}}/zig-cache" 2>/dev/null; echo "OK: zig outputs cleaned"
+
+# Remove the GhosttyKit framework symlink.
+[group("clean")]
+clean-link:
+  @rm -rf Frameworks/GhosttyKit.xcframework 2>/dev/null; echo "OK: framework link removed"

--- a/README.md
+++ b/README.md
@@ -35,9 +35,71 @@ Most mobile terminals lose your session when the app backgrounds or your connect
 - **Xcode 15+** (full app, not just command-line tools — needed for iOS SDK, simulator, and signing)
 - **iOS 17.0+**
 - **Zig 0.15.2+** — install via `brew install zig` or from [ziglang.org/download](https://ziglang.org/download/)
+- **Metal Toolchain** — required by GhosttyKit build. Install via `xcodebuild -downloadComponent MetalToolchain` (the Justfile installs it automatically)
 - **Apple Developer account** — free Apple ID works for simulator and personal device builds; paid ($99/year) required for TestFlight distribution
 
-## Building
+## Building with Just
+
+The project includes a [Justfile](https://just.systems) that automates the entire build pipeline — cloning repos, checking prerequisites, building dependencies, and compiling the app.
+
+```bash
+brew install just
+```
+
+### Quick start
+
+```bash
+git clone https://github.com/eriklangille/clauntty.git clauntty && cd clauntty
+just deps               # Clone repos, check environment, build ghostty + rtach, link framework
+just build-only         # Build for iOS Simulator
+```
+
+### All recipes
+
+```bash
+just -l                 # List all available recipes
+
+# Setup & checks
+just setup              # Clone sibling repos (ghostty, rtach, libxev) if missing
+just doctor             # Run preflight checks (Xcode, Zig, Metal Toolchain, layout)
+
+# Dependencies
+just deps               # Full dependency pipeline (setup + doctor + build + link)
+just deps-ghostty       # Build GhosttyKit xcframework only
+just deps-rtach         # Build rtach cross-compiled binaries only
+just deps-link          # Symlink GhosttyKit.xcframework into Frameworks/
+just copy-rtach         # Copy rtach binaries into app resources
+
+# Build & test
+just build              # Full build (deps + app)
+just build-only         # Build for simulator (skip deps, faster iteration)
+just test               # Run unit tests on simulator
+
+# Release
+just archive            # Build .xcarchive for device (signing required)
+just ipa                # Export .ipa from archive
+
+# Configuration
+just configure <bundle_id> <team_id> <url_scheme>  # Patch fork identity
+
+# Clean
+just clean              # Clean everything (Xcode, DerivedData, zig outputs, framework link)
+just clean-xcode        # Xcode clean only
+just clean-derived      # Remove DerivedData
+just clean-zig          # Remove zig-out/zig-cache in ghostty + rtach
+just clean-link         # Remove framework symlink
+```
+
+Most variables can be overridden via environment:
+
+```bash
+SIM_DEVICE="iPhone 16 Pro" just build-only    # Different simulator
+CONFIGURATION=Release just build-only          # Release build
+```
+
+## Building manually
+
+If you prefer not to use Just, follow these steps.
 
 ### 1. Clone the repos
 
@@ -46,7 +108,7 @@ The project is a monorepo with 4 sibling repos. **The directory layout matters**
 ```bash
 mkdir clauntty && cd clauntty
 git clone https://github.com/eriklangille/clauntty.git clauntty
-git clone https://github.com/eriklangille/ghostty.git ghostty
+git clone -b clauntty https://github.com/eriklangille/ghostty.git ghostty
 git clone https://github.com/eriklangille/rtach.git rtach
 git clone https://github.com/eriklangille/libxev.git libxev
 ```
@@ -68,7 +130,7 @@ Build in this order — each step depends on the previous:
 # 1. Build GhosttyKit framework (requires libxev at ../libxev)
 cd ghostty && zig build -Demit-xcframework -Doptimize=ReleaseFast && cd ..
 
-# 2. Build rtach Linux binaries (auto-copies to clauntty/Clauntty/Resources/rtach/)
+# 2. Build rtach Linux binaries
 cd rtach && zig build cross && cd ..
 ```
 
@@ -78,7 +140,7 @@ ls clauntty/Frameworks/GhosttyKit.xcframework
 ```
 If missing, create it:
 ```bash
-ln -s ../../ghostty/zig-out/GhosttyKit.xcframework clauntty/Frameworks/GhosttyKit.xcframework
+ln -s ../../ghostty/macos/GhosttyKit.xcframework clauntty/Frameworks/GhosttyKit.xcframework
 ```
 
 ### 3. Build the iOS app
@@ -114,7 +176,13 @@ xcrun devicectl device install app --device "<YOUR DEVICE>" \
 
 ### Building your own fork
 
-To ship under your own identity, update these:
+To ship under your own identity, use the Justfile:
+
+```bash
+just configure com.yourcompany.clauntty YOUR_TEAM_ID yourclauntty
+```
+
+Or update manually:
 
 | What | Where | Current value |
 |------|-------|---------------|
@@ -123,7 +191,7 @@ To ship under your own identity, update these:
 | Team ID | `ExportOptions.plist` → `teamID` | `65533RB4LC` |
 | URL scheme | `Clauntty/Info.plist` → `CFBundleURLSchemes` | `clauntty` |
 
-The easiest way: open `Clauntty.xcodeproj` in Xcode, select the Clauntty target, go to **Signing & Capabilities**, and pick your team. Xcode will update the bundle ID and signing automatically.
+The easiest way without Just: open `Clauntty.xcodeproj` in Xcode, select the Clauntty target, go to **Signing & Capabilities**, and pick your team. Xcode will update the bundle ID and signing automatically.
 
 ## Project Structure
 
@@ -214,7 +282,7 @@ uv run scripts/parse_crash.py --latest
 ```bash
 # Unit tests
 xcodebuild test -project Clauntty.xcodeproj -scheme ClaunttyTests \
-  -destination 'platform=iOS Simulator,name=iPhone 16'
+  -destination 'platform=iOS Simulator,name=iPhone 17'
 
 # Local SSH test server (Docker)
 ./scripts/docker-ssh/ssh-test-server.sh start


### PR DESCRIPTION
## Summary

  Adds a Justfile that automates the entire build pipeline — from cloning sibling repos to exporting an IPA. Also fixes several inconsistencies found in README.md and CLAUDE.md while ensuring the Justfile matched the actual project state.

  ## What's in the Justfile

  A single `just deps && just build-only` replaces the manual multi-step setup (clone 3 repos, checkout correct branch, build ghostty, build rtach, symlink framework, copy binaries, then xcodebuild). All recipes are grouped and discoverable via `just
  -l`.

  ### Recipes

  | Group | Recipe | What it does |
  |-------|--------|--------------|
  | **setup** | `setup` | Clones ghostty, rtach, libxev if missing; checks out the `clauntty` branch on ghostty |
  | **check** | `doctor` | Preflight checks: macOS, Xcode 15+, Zig 0.15.2+, Metal Toolchain (auto-installs if missing), directory layout |
  | **deps** | `deps` | Full pipeline: setup → doctor → build ghostty + rtach (in parallel) → symlink framework → copy rtach binaries |
  | **deps** | `deps-ghostty` | Build GhosttyKit xcframework only |
  | **deps** | `deps-rtach` | Build rtach cross-compiled binaries only |
  | **deps** | `deps-link` | Symlink GhosttyKit.xcframework into Frameworks/ |
  | **deps** | `copy-rtach` | Copy rtach binaries into app resources |
  | **build** | `build` | Full build (deps + simulator build) |
  | **build** | `build-only` | Simulator build only (fast iteration, skips deps) |
  | **build** | `test` | Run unit tests on simulator |
  | **release** | `archive` | Build .xcarchive for device (signing required) |
  | **release** | `ipa` | Export .ipa from archive |
  | **config** | `configure` | Patch bundle ID, team ID, URL scheme across pbxproj, plists, and sim.sh |
  | **clean** | `clean` | Clean everything (with confirmation prompt) |
  | **clean** | `clean-xcode` / `clean-derived` / `clean-zig` / `clean-link` | Granular clean targets |

  ### Features

  - **Parallel dependency builds** — ghostty and rtach build simultaneously via `[parallel]`
  - **Auto-install Metal Toolchain** — `doctor` detects and installs it if missing
  - **All configurable via env vars** — override any default (`SIM_DEVICE`, `CONFIGURATION`, `GHOSTTY_DIR`, etc.)
  - **Self-contained setup** — `just setup` clones all sibling repos and checks out the correct ghostty branch
  - **Confirmation on destructive ops** — `just clean` prompts before deleting build artifacts
  - **Framework symlink uses relative path** — portable across machines, matches the existing tracked symlink

  ## Doc fixes

  ### README.md
  - Fixed wrong framework symlink path (`zig-out/` → `macos/`)
  - Added missing `-b clauntty` branch to ghostty clone command
  - Fixed stale simulator device name (`iPhone 16` → `iPhone 17`)
  - Added Metal Toolchain to requirements
  - Added "Building with Just" section with quick start and full recipe reference
  - Renamed existing instructions to "Building manually" as fallback
  - Added `just configure` as option in the "Building your own fork" section

  ### CLAUDE.md
  - Updated architecture diagram to include SessionManager, RtachClient, connection pooling
  - Updated data flow to go through rtach (was direct SSH → ghostty)
  - Added rtach to repository layout
  - Added RtachDeployer, SessionManager, RtachClient to key files table
  - Added `-Doptimize=ReleaseFast` to ghostty build command
  - Moved tabs, rtach integration, RtachClient module from TODO to Working
  - Added Justfile section to Build Commands

  ## How to install

  ```bash
  brew install just
  ```